### PR TITLE
Fix install script updating refind.conf

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -1,65 +1,84 @@
 #!/bin/bash
 
 clear
-cd $HOME
 echo "Downloading Refind Theme to "$HOME" [NOT DONE]"
+
+cd $HOME
 git clone https://github.com/bobafetthotmail/refind-theme-regular.git &> /dev/null
+
 sleep 1
 clear
 echo "Downloading Refind Theme to "$HOME" [DONE]"
 echo "Deleting older installed versions (If any) [NOT DONE]"
+
 sudo rm -rf /boot/efi/EFI/refind/{regular-theme,refind-theme-regular}
+
 sleep 1
 clear
 echo "Downloading Refind Theme to "$HOME" [DONE]"
 echo "Deleteting older installed versions (If any) [DONE]"
 echo "Copying Theme to /boot/efi/EFI/refind/ [NOT DONE]"
+
 sudo cp -r refind-theme-regular /boot/efi/EFI/refind/
+
 sleep 1
 clear
 echo "Downloading Refind Theme to "$HOME" [DONE]"
 echo "Deleteting older installed versions (If any) [DONE]"
 echo "Copying Theme to /boot/efi/EFI/refind/ [DONE]"
 echo "Removing unused directories [NOT DONE]"
+
 sudo rm -rf /boot/efi/EFI/refind/refind-theme-regular/{src,.git}
+
 sleep 1
 clear
 echo "Downloading Refind Theme to "$HOME" [DONE]"
 echo "Deleteting older installed versions (If any) [DONE]"
 echo "Copying Theme to /boot/efi/EFI/refind/ [DONE]"
 echo "Removing unused directories [DONE]"
-echo "Removing old themes [NOT DONE]"
-sed '/include/d' ./boot/efi/EFI/refind/refind.conf &> /dev/null
+echo "Removing old themes from refind.conf [NOT DONE]"
+
+sudo sed --in-place=".bak" 's/^\s*include/# (disabled) include/' /boot/efi/EFI/refind/refind.conf
+
 sleep 1
 clear
 echo "Downloading Refind Theme to "$HOME" [DONE]"
 echo "Deleteting older installed versions (If any) [DONE]"
 echo "Copying Theme to /boot/efi/EFI/refind/ [DONE]"
 echo "Removing unused directories [DONE]"
-echo "Removing old themes [DONE]"
-echo "Updating theme.config [NOT DONE]"
-echo "include refind-theme-regular/theme.conf" >> /boot/efi/EFI/refind/refind.conf
+echo "Removing old themes from refind.conf [DONE]"
+echo "Updating refind.conf [NOT DONE]"
+
+echo "
+# Load a theme!
+include refind-theme-regular/theme.conf
+" | sudo tee -a /boot/efi/EFI/refind/refind.conf &> /dev/null
+
 sleep 1
 clear
 echo "Downloading Refind Theme to "$HOME" [DONE]"
 echo "Deleteting older installed versions (If any) [DONE]"
 echo "Copying Theme to /boot/efi/EFI/refind/ [DONE]"
 echo "Removing unused directories [DONE]"
-echo "Removing old themes [DONE]"
-echo "Updating theme.config [DONE]"
+echo "Removing old themes from refind.conf [DONE]"
+echo "Updating refind.conf [DONE]"
 echo "Deleting Theme [NOT DONE]"
+
 cd $HOME
 sudo rm -r refind-theme-regular
+
 sleep 1
 clear
 echo "Downloading Refind Theme to "$HOME" [DONE]"
 echo "Deleteting older installed versions (If any) [DONE]"
 echo "Copying Theme to /boot/efi/EFI/refind/ [DONE]"
 echo "Removing unused directories [DONE]"
-echo "Removing old themes [DONE]"
-echo "Updating theme.config [DONE]"
+echo "Removing old themes from refind.conf [DONE]"
+echo "Updating refind.conf [DONE]"
 echo "Deleting Theme [DONE]"
+
 sleep 1
 echo "  "
 echo "Thank you for installing refind-theme-regular."
-echo "NOTE: If your not geting your full resolution then try disabling the CSM in your UEFI settings." 
+echo "NOTE: If your not geting your full resolution then try disabling the CSM in your UEFI settings."
+


### PR DESCRIPTION
- It did not have superuser privileges for these lines, and they silently failed
- Made it create a backup of the `refind.conf` (`refind.conf.bak`) before updating it
- Made it comment out any `include` lines that are not already commented, without messing with any other occurrences of `include`
- Added a comment before the `include` line it appends (mainly to separate it visually from the block of code above)