### PR TITLE
Improve stability/safeness of the install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,17 +26,15 @@ normal=$(tput sgr0)
 refind_dir="/boot/efi/EFI/refind"
 #Set install path
 echo "Enter rEFInd install location"
-read -e -p "Default - ${bold}/boot/efi/EFI/refind/${normal}: " location
-if test -z "$location";
-then
-    location="/boot/efi/EFI/refind/themes"
+read -e -p "Default - ${bold}${refind_dir}${normal}: " refind_dir
+if [[ ! -d "${refind_dir}" ]]; then
+    echo "Specified rEFInd install location does not exist. Aborting install."
+    exit 1
 fi
-if [[ -d "${location}" ]]; then
-	mkdir -p "${location}"
-fi
-if test "${location: -1}" != "/"
+if test "${refind_dir: -1}" == "/"
 then
-    location="$location/"
+    # remove trailing slash
+    refind_dir=$(realpath -s "$refind_dir")
 fi
 
 #Set icon size
@@ -117,12 +115,14 @@ echo " - [DONE]"
 
 #Remove previous installs
 echo -n "Deleting older installed versions (if any)"
-rm -rf "$location"{regular-theme,refind-theme-regular}
+rm -rf "${refind_dir}"/{regular-theme,refind-theme-regular}
+rm -rf "${refind_dir}"/themes/{regular-theme,refind-theme-regular}
 echo " - [DONE]"
 
 #Copy theme setup folders
-echo -n "Copying theme to $location"
-cp -r refind-theme-regular "$location"
+echo -n "Copying theme to ${refind_dir}/themes"
+mkdir -p "${refind_dir}/themes"
+cp -r refind-theme-regular "${refind_dir}/themes"
 echo " - [DONE]"
 
 #Edit refind.conf - remove older themes

--- a/install.sh
+++ b/install.sh
@@ -33,11 +33,8 @@ if [[ ! -d "${refind_dir}" ]]; then
     echo "Specified rEFInd install location does not exist. Aborting install."
     exit 1
 fi
-if test "${refind_dir: -1}" == "/"
-then
-    # remove trailing slash
-    refind_dir=$(realpath -s "$refind_dir")
-fi
+# remove trailing slash
+refind_dir=$(realpath -s "$refind_dir")
 
 #Set icon size
 echo "Pick an icon size: (larger icons look better on bigger and denser displays)"

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,9 @@ then
 fi
 
 #Clone the theme
-echo -n "Downloading rEFInd theme Regular to $PWD"
+theme_source_directory=$(mktemp -d -t refind-theme-regular-XXXXXX)
+cd "${theme_source_directory}"
+echo -n "Downloading rEFInd theme Regular to ${theme_source_directory}"
 git clone https://github.com/bobafetthotmail/refind-theme-regular.git &> /dev/null
 echo " - [DONE]"
 
@@ -168,8 +170,8 @@ then
 fi
 case "$del_confirm" in
     y|Y)
-        echo -n "Deleting download"
-        rm -r refind-theme-regular
+        echo -n "Deleting download folder ${theme_source_directory}"
+        rm -r "${theme_source_directory}"
         echo " - [DONE]"
         ;;
     *)

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -euo pipefail
 # An installer for refind-theme-regular by Munlik
 
 #Check if root


### PR DESCRIPTION
In particular

* only use one variable for the install directory, currently two variables were used but only one was pointing to the user-specified location, so it would fail on custom installations (when the path was not /boot/efi/EFI/refind)
* enable bash error traps, so that if an error happens, the script fails and does not continue execution, which would lead to potential bugs
* download the install directory in a temporary directory, so multiple `git clone` do not cause a problem